### PR TITLE
Update ViteHelper.php

### DIFF
--- a/src/Helper/ViteHelper.php
+++ b/src/Helper/ViteHelper.php
@@ -67,7 +67,7 @@ class ViteHelper extends ViewableData implements TemplateGlobalProvider
         return '';
     }
 
-    public static function Vite($path): string
+    public static function Vite($path, int $getCSSFile = null): string
     {
         $instance = singleton(self::class);
 
@@ -79,8 +79,13 @@ class ViteHelper extends ViewableData implements TemplateGlobalProvider
                 user_error('manifest file does not exist. Did you build?', E_USER_ERROR);
             $manifest = json_decode(file_get_contents($manifestPath), true);
             $outputUrl = RESOURCES_DIR . $instance->config()->get('output_url');
-            $path = $outputUrl . $manifest[$path]['file'];
-            return Convert::raw2att($path);
+
+            if ($getCSSFile) {
+                $path = $outputUrl . $manifest[$path]['css'][$getCSSFile - 1];
+            } else {
+                $path = $outputUrl . $manifest[$path]['file'];
+            }
+            return Convert::raw2att("/{$path}");
         }
     }
 


### PR DESCRIPTION
- Fixed a bug where the path was appended to the current URL instead of appending to the base_url.

- Added a feature to get the underlying CSS files of a manifest file. This is added because, when Vue a file is being processed, the CSS of the Vue file is generated separately and not added as a separate file in the manifest.